### PR TITLE
Update travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,10 @@ php:
 
   # aliased to 5.2.17
   - 5.2
+    dist: precise
   # aliased to 5.3.29
   - 5.3
+    dist: precise
   # aliased to a recent 5.4.x version
   - 5.4
   # aliased to a recent 5.5.x version


### PR DESCRIPTION
PHP 5.2 and 5.3 are supported only on Precise.
See https://docs.travis-ci.com/user/reference/trusty#PHP-images on how to test PHP 5.3 on Precise.
Terminating.